### PR TITLE
Refactored sampling methods to make them faster

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -1,11 +1,11 @@
 # None of these functions are exported
 #---- Argument checking ----
 not_positive_vector <- function(x) {
-  !(is.numeric(x) && all(is.finite(x)) && all(x >= 0))
+  !(length(x) > 0 && is.numeric(x) && all(is.finite(x)) && all(x >= 0))
 }
 
 not_strict_positive_vector <- function(x) {
-  !(is.numeric(x) && all(is.finite(x)) && all(x > 0))
+  !(length(x) > 0 && is.numeric(x) && all(is.finite(x)) && all(x > 0))
 }
 
 not_positive_number <- function(x) {

--- a/man/sps.Rd
+++ b/man/sps.Rd
@@ -15,21 +15,21 @@ Draw a stratified probability-proportional-to-size sample according to the seque
 }
 
 \usage{
-sps(x, n, s = single_stratum(x), prn = NULL)
+sps(x, n, s = gl(1, length(x)), prn = NULL)
 
-ps(x, n, s = single_stratum(x), prn = NULL)
+ps(x, n, s = gl(1, length(x)), prn = NULL)
 
 \method{weights}{sps}(object, ...)
 
-inclusion_prob(x, n, s = single_stratum(x))
+inclusion_prob(x, n, s = gl(1, length(x)))
 
 prop_allocation(
-  x, N, s = single_stratum(x), min = 0, 
+  x, N, s = gl(1, length(x)), min = 0, 
   method = c("Largest-remainder", "D'Hondt", "Webster", "Imperiali", 
              "Huntington-Hill", "Danish", "Adams", "Dean") 
 )
 
-expected_coverage(x, N, s = single_stratum(x))
+expected_coverage(x, N, s = gl(1, length(x)))
 }
 
 \arguments{

--- a/tests/test-coverage.R
+++ b/tests/test-coverage.R
@@ -1,6 +1,6 @@
 library(sps)
 
-all.equal(expected_coverage(numeric(0), integer(0)), 0)
+#all.equal(expected_coverage(numeric(0), integer(0)), 0)
 all.equal(expected_coverage(1:6, 6), 1)
 all.equal(expected_coverage(1:6, 0), 0)
 all.equal(expected_coverage(1:6, 3, 1:6), 3)

--- a/tests/test-inclusion.R
+++ b/tests/test-inclusion.R
@@ -1,8 +1,8 @@
 library(sps)
 
 # Corner cases
-all.equal(inclusion_prob(numeric(0), integer(0)), numeric(0))
-all.equal(inclusion_prob(numeric(0), 0, gl(1, 0)), numeric(0))
+#all.equal(inclusion_prob(numeric(0), integer(0)), numeric(0))
+#all.equal(inclusion_prob(numeric(0), 0, gl(1, 0)), numeric(0))
 all.equal(
   inclusion_prob(1:3, c(0, 1, 0), factor(c(2, 2, 2), levels = 1:3)),
   1:3 / 6

--- a/tests/test_sps.R
+++ b/tests/test_sps.R
@@ -28,7 +28,7 @@ is.integer(sps(1, 1))
 is.integer(sps(1:4, c(1, 2), c(1, 1, 2, 2)))
 
 # Strata sizes should add up
-s <- sample(letters, 100, TRUE)
+s <- factor(sample(letters, 100, TRUE), letters)
 x <- runif(100)
 alloc <- prop_allocation(x, 50, s)
 res <- s[sps(x, alloc, s)]


### PR DESCRIPTION
The sps() function is unnecessarily slow when drawing large samples. As discussed, I've refactored parts of sps.R to make it faster. In particular, I added a helper .inclusion_probability_list() to return a list of inclusion probs by stratum. This saves from unsplitting then splitting in stratify() and cuts the execution time and memory use by ~25%.

Also, as discussed, I updated some of the argument checking to avoid complexity when dealing with length-zero vectors. These changes prevent passing integer(0) as the sample size (like base sample and prop_allocation), and missing strata.

Some tests no longer apply and I've commented these out.